### PR TITLE
Feature/apps 1521 move actions to person reducer

### DIFF
--- a/src/containers/person/SearchPersonContainer.js
+++ b/src/containers/person/SearchPersonContainer.js
@@ -3,13 +3,16 @@
  */
 
 import React from 'react';
-
-import Immutable from 'immutable';
+import { List, Map } from 'immutable';
 import styled from 'styled-components';
 import qs from 'query-string';
+import type { RequestState } from 'redux-reqseq';
 import { DateTime } from 'luxon';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExclamationTriangle } from '@fortawesome/pro-light-svg-icons';
 
 import PersonSearchFields from '../../components/person/PersonSearchFields';
 import SecondaryButton from '../../components/buttons/SecondaryButton';
@@ -17,10 +20,19 @@ import PersonTable from '../../components/people/PersonTable';
 import LogoLoader from '../../components/LogoLoader';
 import NoSearchResults from '../../components/people/NoSearchResults';
 import { clearSearchResults, searchPeople } from './PersonActions';
-import { StyledFormViewWrapper, StyledSectionWrapper, StyledFormWrapper } from '../../utils/Layout';
 import { PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
-import { STATE, SEARCH } from '../../utils/consts/FrontEndStateConsts';
+import { SEARCH } from '../../utils/consts/FrontEndStateConsts';
 import { OL } from '../../utils/consts/Colors';
+import {
+  StyledFormViewWrapper,
+  StyledSectionWrapper,
+  StyledFormWrapper,
+  WarningText
+} from '../../utils/Layout';
+
+import { STATE } from '../../utils/consts/redux/SharedConsts';
+import { getReqState, getError, requestIsFailure } from '../../utils/consts/redux/ReduxUtils';
+import { FAILED_CASES, PERSON_ACTIONS } from '../../utils/consts/redux/PersonConsts';
 
 import * as Routes from '../../core/router/Routes';
 
@@ -52,11 +64,6 @@ const NonResultsContainer = styled.div`
   width: 100%;
   text-align: center;
   margin-top: 50px;
-`;
-
-const LoadingText = styled.div`
-  font-size: 20px;
-  margin: 15px;
 `;
 
 const ListSectionHeader = styled.div`
@@ -93,6 +100,13 @@ const CreateButtonWrapper = styled(StyledFormViewWrapper)`
   }
 `;
 
+const StyledWarningText = styled(WarningText)`
+  font-size: 14px;
+  font-weight: 600;
+  justify-content: center;
+  padding: 30px;
+`;
+
 const SearchResultsWrapper = styled(StyledSectionWrapper)`
   padding: 0;
 `;
@@ -107,12 +121,14 @@ type Props = {
     clearSearchResults :Function,
     searchPeople :Function
   },
-  isLoadingPeople :boolean,
-  searchHasRun :boolean,
-  searchResults :Immutable.List<Immutable.Map<*, *>>,
-  onSelectPerson :Function,
+  error :boolean,
   history :string[],
-  error :boolean
+  isLoadingPeople :boolean,
+  onSelectPerson :Function,
+  searchHasRun :boolean,
+  searchResults :List<Map<*, *>>,
+  updateCasesError :Map<*, *>,
+  updateCasesReqState :RequestState,
 }
 
 type State = {
@@ -137,7 +153,7 @@ class SearchPeopleContainer extends React.Component<Props, State> {
     actions.clearSearchResults();
   }
 
-  handleOnSelectPerson = (person :Immutable.Map, entityKeyId :string, personId :string) => {
+  handleOnSelectPerson = (person :Map, entityKeyId :string, personId :string) => {
     const { onSelectPerson } = this.props;
     onSelectPerson(person, entityKeyId, personId);
   }
@@ -148,6 +164,22 @@ class SearchPeopleContainer extends React.Component<Props, State> {
       actions.searchPeople({ firstName, lastName, dob });
       this.setState({ firstName, lastName, dob });
     }
+  }
+
+  renderCaseLoaderError = () => {
+    const { updateCasesReqState, updateCasesError } = this.props;
+    const updateCasesFailed = requestIsFailure(updateCasesReqState);
+    if (updateCasesFailed) {
+      const failedCases = updateCasesError.get(FAILED_CASES, List());
+      const statusText = `Failed to load the following cases: ${failedCases.join(', ')}.`;
+      return (
+        <StyledWarningText>
+          <FontAwesomeIcon color={OL.RED01} icon={faExclamationTriangle} />
+          { statusText }
+        </StyledWarningText>
+      );
+    }
+    return null;
   }
 
   createNewPerson = () => {
@@ -169,7 +201,7 @@ class SearchPeopleContainer extends React.Component<Props, State> {
   }
 
   getSortedPeopleList = (peopleList, gray) => {
-    const rows = peopleList.sort((p1 :Immutable.Map<*, *>, p2 :Immutable.Map<*, *>) => {
+    const rows = peopleList.sort((p1 :Map<*, *>, p2 :Map<*, *>) => {
       const p1Last = p1.getIn([PROPERTY_TYPES.LAST_NAME, 0], '').toLowerCase();
       const p2Last = p2.getIn([PROPERTY_TYPES.LAST_NAME, 0], '').toLowerCase();
       if (p1Last !== p2Last) return p1Last < p2Last ? -1 : 1;
@@ -237,8 +269,8 @@ class SearchPeopleContainer extends React.Component<Props, State> {
     }
 
     /* search has finished running and there are results -- display the results */
-    let peopleWithHistory = Immutable.List();
-    let peopleWithoutHistory = Immutable.List();
+    let peopleWithHistory = List();
+    let peopleWithoutHistory = List();
 
     searchResults.forEach((person) => {
       const id = person.getIn([PROPERTY_TYPES.PERSON_ID, 0], '');
@@ -284,6 +316,7 @@ class SearchPeopleContainer extends React.Component<Props, State> {
       <Wrapper>
         <StyledFormViewWrapper>
           <StyledFormWrapper>
+            {/* { this.renderCaseLoaderError() } */}
             <StyledSectionWrapper>
               <PersonSearchFields handleSubmit={this.handleOnSubmitSearch} />
             </StyledSectionWrapper>
@@ -296,11 +329,16 @@ class SearchPeopleContainer extends React.Component<Props, State> {
   }
 }
 
-function mapStateToProps(state :Immutable.Map<*, *>) :Object {
+function mapStateToProps(state :Map<*, *>) :Object {
   const search = state.get(STATE.SEARCH);
+  const person = state.get(STATE.PERSON);
   // TODO: error is not in SearchReducer
   return {
-    [SEARCH.SEARCH_RESULTS]: search.get(SEARCH.SEARCH_RESULTS, Immutable.List()),
+    // Person
+    updateCasesReqState: getReqState(person, PERSON_ACTIONS.UPDATE_CASES),
+    updateCasesError: getError(person, PERSON_ACTIONS.UPDATE_CASES),
+    // Search
+    [SEARCH.SEARCH_RESULTS]: search.get(SEARCH.SEARCH_RESULTS, List()),
     [SEARCH.LOADING]: search.get(SEARCH.LOADING, false),
     [SEARCH.SEARCH_HAS_RUN]: search.get(SEARCH.SEARCH_HAS_RUN),
     error: search.get('searchError', false)

--- a/src/containers/psa/FormContainer.js
+++ b/src/containers/psa/FormContainer.js
@@ -78,9 +78,14 @@ import {
 } from '../../utils/Helpers';
 
 import { STATE } from '../../utils/consts/redux/SharedConsts';
-import { getReqState, requestIsPending, requestIsSuccess } from '../../utils/consts/redux/ReduxUtils';
 import { APP_DATA } from '../../utils/consts/redux/AppConsts';
 import { PERSON_ACTIONS, PERSON_DATA } from '../../utils/consts/redux/PersonConsts';
+import {
+  getError,
+  getReqState,
+  requestIsFailure,
+  requestIsPending,
+} from '../../utils/consts/redux/ReduxUtils';
 
 import * as Routes from '../../core/router/Routes';
 import { loadPersonDetails } from '../person/PersonActions';
@@ -411,9 +416,19 @@ class Form extends React.Component<Props, State> {
   }
 
   redirectToFirstPageIfNecessary = () => {
-    const { psaForm, actions, selectedPerson } = this.props;
+    const {
+      psaForm,
+      actions,
+      selectedPerson,
+      updateCasesReqState
+    } = this.props;
     const { scoresWereGenerated } = this.state;
     const loadedContextParams = this.loadContextParams();
+    // const updatingCasesFailed = requestIsFailure(updateCasesReqState);
+    // if (updatingCasesFailed) {
+    //   actions.goToPath(`${Routes.PSA_FORM}/1`);
+    //   this.clear();
+    // }
     if (loadedContextParams) {
       actions.goToPath(`${Routes.PSA_FORM}/1`);
     }
@@ -1143,6 +1158,7 @@ function mapStateToProps(state :Immutable.Map<*, *>) :Object {
     [PERSON_DATA.SELECTED_PERSON_ID]: person.get(PERSON_DATA.SELECTED_PERSON_ID),
     [PERSON_DATA.LOADING_PERSON_DETAILS]: person.get(PERSON_DATA.LOADING_PERSON_DETAILS),
     updateCasesReqState: getReqState(person, PERSON_ACTIONS.UPDATE_CASES),
+    updateCasesError: getError(person, PERSON_ACTIONS.UPDATE_CASES),
     [PERSON_DATA.NUM_CASES_TO_LOAD]: person.get(PERSON_DATA.NUM_CASES_TO_LOAD),
     [PERSON_DATA.NUM_CASES_LOADED]: person.get(PERSON_DATA.NUM_CASES_LOADED),
   };

--- a/src/containers/reminders/RemindersReducer.js
+++ b/src/containers/reminders/RemindersReducer.js
@@ -91,6 +91,7 @@ export default function remindersReducer(state :Map<*, *> = INITIAL_STATE, actio
             .setIn([REDUX.ACTIONS, REMINDERS_ACTIONS.BULK_DOWNLOAD_REMINDERS_PDF, REDUX.REQUEST_STATE], FAILURE);
         },
         FINALLY: () => state
+          .setIn([REDUX.ACTIONS, REMINDERS_ACTIONS.BULK_DOWNLOAD_REMINDERS_PDF, REDUX.REQUEST_STATE], STANDBY)
           .deleteIn([REDUX.ACTIONS, REMINDERS_ACTIONS.BULK_DOWNLOAD_REMINDERS_PDF, action.id])
       });
     }

--- a/src/core/router/Routes.js
+++ b/src/core/router/Routes.js
@@ -50,7 +50,7 @@ const CHECKINS :string = 'checkins';
 export const MANAGE_HEARINGS :string = 'manage-hearings';
 
 /* people */
-export const REMINDERS :string = '/reminders';
+export const REMINDERS :string = 'reminders';
 export const PERSON = `${DASHBOARD}/person`;
 export const PEOPLE = `${DASHBOARD}/people`;
 export const SEARCH_PEOPLE = `${PEOPLE}/search`;

--- a/src/utils/Layout.js
+++ b/src/utils/Layout.js
@@ -679,3 +679,15 @@ export const Data = styled.div`
   font-size: 14px;
   color: ${OL.GREY15};
 `;
+
+export const WarningText = styled.div`
+  color: ${OL.RED01};
+  display: flex;
+  flex-direction: row;
+  font-size: 12px;
+  justify-content: flex-end;
+  width: 100%;
+  svg {
+    margin: 2px;
+  }
+`;

--- a/src/utils/consts/redux/PersonConsts.js
+++ b/src/utils/consts/redux/PersonConsts.js
@@ -16,3 +16,5 @@ export const PERSON_DATA = {
   SUBMITTED_PERSON: 'submittedPerson',
   SUBMITTED_PERSON_NEIGHBORS: 'submittedPersonNeighbors'
 };
+
+export const FAILED_CASES = 'failedCases';

--- a/src/utils/consts/redux/RemindersConsts.js
+++ b/src/utils/consts/redux/RemindersConsts.js
@@ -26,3 +26,5 @@ export const REMINDERS_DATA = {
   REMINDERS_WITH_OPEN_PSA_IDS: 'remindersWithOpenPSA',
   SUCCESSFUL_REMINDER_IDS: 'successfulReminderIds',
 };
+
+export const NO_HEARING_IDS = 'There are no heairngs scheduled on';


### PR DESCRIPTION
- Moved `getPersonDetails` and `updateCases` to `PersonReducer`.
- Switched to `Request States` for `getPersonDetails` and `updateCases`.
- The check for all cases loaded in order to call `getPersonDetails` and `loadNeighbors` has been moved to `updateCasesWorker`.
- Only actions that are used were imported in `PSAModal` and `FormContainer`. 