### PR TITLE
APPS-1533 Grab bonds, outcomes, and release conditions from Hearing Neighbors, 

### DIFF
--- a/src/containers/download/DownloadSagas.js
+++ b/src/containers/download/DownloadSagas.js
@@ -326,8 +326,6 @@ function* downloadPSAsWorker(action :SequenceAction) :Generator<*, *, *> {
             sourceEntitySetIds: [
               bondsEntitySetId,
               outcomesEntitySetId,
-              peopleEntitySetId,
-              psaEntitySetId,
               releaseConditionsEntitySetId
             ],
             destinationEntitySetIds: []


### PR DESCRIPTION
At some point we were not associating bonds, outcomes, and release conditions to PSAs. These are needed for the bulk download.