### PR TITLE
Feature/apps 1654 for case history default to PSA timestamp if no arrest time

### DIFF
--- a/src/utils/CaseUtils.js
+++ b/src/utils/CaseUtils.js
@@ -127,7 +127,7 @@ export const getCasesForPSA = (
   } = getEntityProperties(scores, [STATUS, TIMESTAMP]);
   const psaIsClosed = status !== PSA_STATUSES.OPEN;
 
-  const psaArrestDateTime = DateTime.fromISO(arrestDate || psaDateTime || undefined);
+  const psaArrestDateTime = DateTime.fromISO(arrestDate || psaDateTime);
   const psaClosureDate = psaIsClosed ? DateTime.fromISO(lastEditDateForPSA) : DateTime.local().plus({ days: 1 });
 
 


### PR DESCRIPTION
When displaying case history for a given PSA, we're only showing cases that are between the arrest date and the PSA closure date. A person was found without an arrest, so it showed no cases. So we're going to default to the PSA creation date if the arrest date is not present. 