### PR TITLE
APPS-2951 Remove In-custody calls from AppContainer

### DIFF
--- a/src/containers/app/AppContainer.js
+++ b/src/containers/app/AppContainer.js
@@ -60,7 +60,6 @@ import {
 import * as Routes from '../../core/router/Routes';
 import { loadApp, switchOrganization } from './AppActionFactory';
 import { loadArrestingAgencies, loadCharges, LOAD_CHARGES } from '../charges/ChargeActions';
-import { getInCustodyData } from '../incustody/InCustodyActions';
 import { loadCounties } from '../counties/CountiesActions';
 import { loadJudges } from '../judges/JudgeActions';
 import { getStaffEKIDs } from '../people/PeopleActions';
@@ -109,7 +108,6 @@ const AppBodyWrapper = styled.div`
 type Props = {
   actions :{
     getAllPropertyTypes :RequestSequence;
-    getInCustodyData :RequestSequence;
     getStaffEKIDs :RequestSequence;
     initializeSettings :RequestSequence;
     loadApp :RequestSequence;
@@ -143,7 +141,6 @@ class AppContainer extends React.Component<Props, {}> {
     if (nextOrgId && prevOrgId !== nextOrgId) {
       this.initializeSettings();
       actions.loadCounties();
-      actions.getInCustodyData();
       actions.loadJudges();
       actions.loadCharges();
       actions.getStaffEKIDs();
@@ -316,8 +313,6 @@ const mapDispatchToProps = (dispatch :Dispatch<any>) => ({
     // Charge Actions
     loadArrestingAgencies,
     loadCharges,
-    // In-Custody Actions
-    getInCustodyData,
     // Coutnies Actions
     loadCounties,
     // Judges Actions

--- a/src/containers/download/DownloadPSA.js
+++ b/src/containers/download/DownloadPSA.js
@@ -3,13 +3,9 @@
  */
 
 import React from 'react';
+
 import styled from 'styled-components';
-import type { Dispatch } from 'redux';
-import type { RequestSequence } from 'redux-reqseq';
-import { DateTime } from 'luxon';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { Map, List } from 'immutable';
+import { List, Map } from 'immutable';
 import {
   Button,
   Checkbox,
@@ -17,26 +13,22 @@ import {
   DateTimePicker,
   Select
 } from 'lattice-ui-kit';
-
-import LogoLoader from '../../components/LogoLoader';
-import InCustodyDownloadButton from '../incustody/InCustodyReportButton';
-import { InstructionalSubText } from '../../components/TextStyledComponents';
-import { OL } from '../../utils/consts/Colors';
-import { MODULE, SETTINGS } from '../../utils/consts/AppSettingConsts';
-import { PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
-import { DOWNLOAD } from '../../utils/consts/FrontEndStateConsts';
-
-import { STATE } from '../../utils/consts/redux/SharedConsts';
-import { APP_DATA } from '../../utils/consts/redux/AppConsts';
-import { IN_CUSTODY_ACTIONS, IN_CUSTODY_DATA } from '../../utils/consts/redux/InCustodyConsts';
-import { SETTINGS_DATA } from '../../utils/consts/redux/SettingsConsts';
-import { getReqState } from '../../utils/consts/redux/ReduxUtils';
+import { DateTime } from 'luxon';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import type { Dispatch } from 'redux';
+import type { RequestSequence } from 'redux-reqseq';
 
 import {
-  REPORT_TYPES,
-  PSA_RESPONSE_TABLE,
-  SUMMARY_REPORT
-} from '../../utils/downloads/ReportDownloadTypes';
+  downloadPSAsByHearingDate,
+  downloadPsaForms,
+  downloadReminderData,
+  getDownloadFilters
+} from './DownloadActions';
+
+import InCustodyDownloadButton from '../incustody/InCustodyReportButton';
+import LogoLoader from '../../components/LogoLoader';
+import { InstructionalSubText } from '../../components/TextStyledComponents';
 import {
   NoResults,
   StyledFormViewWrapper,
@@ -44,13 +36,21 @@ import {
   StyledSectionWrapper,
   StyledTopFormNavBuffer
 } from '../../utils/Layout';
-
+import { MODULE, SETTINGS } from '../../utils/consts/AppSettingConsts';
+import { OL } from '../../utils/consts/Colors';
+import { PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
+import { DOWNLOAD } from '../../utils/consts/FrontEndStateConsts';
+import { APP_DATA } from '../../utils/consts/redux/AppConsts';
+import { IN_CUSTODY_ACTIONS, IN_CUSTODY_DATA } from '../../utils/consts/redux/InCustodyConsts';
+import { getReqState } from '../../utils/consts/redux/ReduxUtils';
+import { SETTINGS_DATA } from '../../utils/consts/redux/SettingsConsts';
+import { STATE } from '../../utils/consts/redux/SharedConsts';
 import {
-  downloadPsaForms,
-  downloadPSAsByHearingDate,
-  downloadReminderData,
-  getDownloadFilters
-} from './DownloadActions';
+  PSA_RESPONSE_TABLE,
+  REPORT_TYPES,
+  SUMMARY_REPORT
+} from '../../utils/downloads/ReportDownloadTypes';
+import { getInCustodyData } from '../incustody/InCustodyActions';
 
 const MONTH_OPTIONS = [
   { label: 'January', value: 1 },
@@ -203,6 +203,7 @@ type Props = {
     downloadPSAsByHearingDate :RequestSequence,
     downloadReminderData :RequestSequence,
     getDownloadFilters :RequestSequence,
+    getInCustodyData :RequestSequence,
   },
   courtroomTimes :Map;
   downloadingReports :boolean;
@@ -241,6 +242,13 @@ class DownloadPSA extends React.Component<Props, State> {
       startDate: '',
       year: null
     };
+  }
+
+  componentDidMount() {
+    const { actions, selectedOrganizationId } = this.props;
+    if (selectedOrganizationId) {
+      actions.getInCustodyData();
+    }
   }
 
   componentDidUpdate(prevProps :Props, prevState :State) {
@@ -660,6 +668,7 @@ const mapDispatchToProps = (dispatch :Dispatch<any>) => ({
     downloadPsaForms,
     downloadPSAsByHearingDate,
     downloadReminderData,
+    getInCustodyData,
     getDownloadFilters
   }, dispatch)
 });

--- a/src/containers/incustody/InCustodyReportButton.js
+++ b/src/containers/incustody/InCustodyReportButton.js
@@ -8,6 +8,7 @@ import type { RequestState } from 'redux-reqseq';
 import { Button } from 'lattice-ui-kit';
 import { connect } from 'react-redux';
 import { Map, Set } from 'immutable';
+import { ReduxUtils } from 'lattice-utils';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowAltCircleDown } from '@fortawesome/pro-light-svg-icons';
@@ -19,7 +20,9 @@ import { STATE } from '../../utils/consts/redux/SharedConsts';
 import REVIEW_DATA from '../../utils/consts/redux/ReviewConsts';
 import { IN_CUSTODY_ACTIONS, IN_CUSTODY_DATA } from '../../utils/consts/redux/InCustodyConsts';
 import { PEOPLE_ACTIONS, PEOPLE_DATA } from '../../utils/consts/redux/PeopleConsts';
-import { getReqState, requestIsPending } from '../../utils/consts/redux/ReduxUtils';
+import { getReqState } from '../../utils/consts/redux/ReduxUtils';
+
+const { isPending } = ReduxUtils;
 
 const ButtonWrapper = styled.div`
   width: 100%;
@@ -29,6 +32,7 @@ const ButtonWrapper = styled.div`
 
 type Props = {
   downloadInCustodyReportReqState :RequestState;
+  getInCustodyDataRequestState :RequestState;
   getPeopleNeighborsReqState :RequestState;
   jailStaysById :Map;
   jailStayNeighborsById :Map;
@@ -43,13 +47,15 @@ class InCustodyDownloadButton extends React.Component<Props, *> {
   isDisabled = () => {
     const {
       downloadInCustodyReportReqState,
+      getInCustodyDataRequestState,
       getPeopleNeighborsReqState,
       loadingResults,
       peopleInCustody
     } = this.props;
     return loadingResults
-      || requestIsPending(downloadInCustodyReportReqState)
-      || requestIsPending(getPeopleNeighborsReqState)
+      || isPending(downloadInCustodyReportReqState)
+      || isPending(getInCustodyDataRequestState)
+      || isPending(getPeopleNeighborsReqState)
       || !peopleInCustody.size;
   }
 
@@ -87,12 +93,13 @@ function mapStateToProps(state) {
   const people = state.get(STATE.PEOPLE, Map());
   const loadPSAsByStatusRS = getReqState(review, LOAD_PSAS_BY_STATUS);
   const loadPSADataRS = getReqState(review, LOAD_PSA_DATA);
-  const loadingPSAsByStatus = requestIsPending(loadPSAsByStatusRS);
-  const loadingPSAData = requestIsPending(loadPSADataRS);
+  const loadingPSAsByStatus = isPending(loadPSAsByStatusRS);
+  const loadingPSAData = isPending(loadPSADataRS);
   const loadingResults = loadingPSAsByStatus || loadingPSAData;
   return {
     // In-Custody
     downloadInCustodyReportReqState: getReqState(inCustody, IN_CUSTODY_ACTIONS.DOWNLOAD_IN_CUSTODY_REPORT),
+    getInCustodyDataRequestState: getReqState(inCustody, IN_CUSTODY_ACTIONS.GET_IN_CUSTODY_DATA),
     [IN_CUSTODY_DATA.JAIL_STAYS_BY_ID]: inCustody.get(IN_CUSTODY_DATA.JAIL_STAYS_BY_ID),
     [IN_CUSTODY_DATA.JAIL_STAY_NEIGHBORS_BY_ID]: inCustody.get(IN_CUSTODY_DATA.JAIL_STAY_NEIGHBORS_BY_ID),
     [IN_CUSTODY_DATA.PEOPLE_IN_CUSTODY]: inCustody.get(IN_CUSTODY_DATA.PEOPLE_IN_CUSTODY),

--- a/src/containers/incustody/InCustodySagas.js
+++ b/src/containers/incustody/InCustodySagas.js
@@ -131,7 +131,8 @@ function* getInCustodyDataWorker(action :SequenceAction) :Generator<*, *, *> {
       const loadPersonNeighborsRequest = getPeopleNeighbors({
         peopleEKIDs: peopleInCustody.keySeq().toJS(),
         srcEntitySets: [PSA_SCORES],
-        dstEntitySets: [CHARGES, PRETRIAL_CASES]
+        dstEntitySets: [CHARGES, PRETRIAL_CASES],
+        dontLoadPSANeighbors: true
       });
       yield put(loadPersonNeighborsRequest);
     }

--- a/src/containers/people/PeopleSagas.js
+++ b/src/containers/people/PeopleSagas.js
@@ -156,7 +156,8 @@ function* getPeopleNeighborsWorker(action) :Generator<*, *, *> {
   const {
     peopleEKIDs,
     srcEntitySets,
-    dstEntitySets
+    dstEntitySets,
+    dontLoadPSANeighbors
   } = action.value;
 
   try {
@@ -349,7 +350,7 @@ function* getPeopleNeighborsWorker(action) :Generator<*, *, *> {
         }
       });
     });
-    if (mostRecentPSAEKIDs.size) {
+    if (!dontLoadPSANeighbors && mostRecentPSAEKIDs.size) {
       const loadPSADataRequest = loadPSAData({ psaIds: mostRecentPSAEKIDs.toJS(), scoresAsMap });
       yield put(loadPSADataRequest);
     }


### PR DESCRIPTION
Moving the In-custody out of the AppContainer and into the Reminders and Download Pages. This way, in-custody data only loads when necessary. 